### PR TITLE
fix: objc without prefix

### DIFF
--- a/packages/pigeon_build_core/lib/src/implementations/build_handler.dart
+++ b/packages/pigeon_build_core/lib/src/implementations/build_handler.dart
@@ -72,6 +72,8 @@ class PigeonBuildHandler {
           objcOptions = ObjcOptions(
             prefix: input.objc?.prefix ?? mainInput!.objc!.prefix,
           );
+        } else {
+          objcOptions = ObjcOptions();
         }
         objcHeaderOut = combineOutFilePath(
           out: input.objc!.headerOut,


### PR DESCRIPTION
Right now if you don't specify a prefix you get a null exception from pigeon because it expects ObjcOptions to be set, see https://github.com/flutter/packages/pull/4756.
