### PR TITLE
Normalize path separators to use forward slash

### DIFF
--- a/packages/pigeon_build_core/lib/src/implementations/build_handler.dart
+++ b/packages/pigeon_build_core/lib/src/implementations/build_handler.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:path/path.dart' as p;
 import 'package:pigeon/pigeon.dart';
 
@@ -6,8 +8,11 @@ import 'package:pigeon_build_config/pigeon_build_config.dart';
 import '../../pigeon_build_core.dart';
 
 class PigeonBuildHandler {
+  final p.Context pathContext =
+      p.Context(style: Platform.isWindows ? p.Style.posix : p.Style.platform);
+
   BuildHandlerResult handleInput(PigeonBuildConfig config, String inputPath) {
-    final nInputPath = normalizePath(inputPath);
+    final nInputPath = pathContext.normalize(inputPath);
     final mainInput = config.mainInput;
 
     if (p.extension(nInputPath) != ".dart") {
@@ -220,10 +225,10 @@ class PigeonBuildHandler {
     } else if (isBase || basePath == null) {
       result = path;
     } else {
-      result = p.join(basePath, path);
+      result = pathContext.join(basePath, path);
     }
 
-    return normalizePath(result);
+    return pathContext.normalize(result);
   }
 
   String? combinePackage(String? package, String? basePackage) {
@@ -236,9 +241,5 @@ class PigeonBuildHandler {
     }
 
     return package;
-  }
-
-  String normalizePath(String path) {
-    return p.normalize(path).replaceAll('\\', '/');
   }
 }

--- a/packages/pigeon_build_core/lib/src/implementations/build_handler.dart
+++ b/packages/pigeon_build_core/lib/src/implementations/build_handler.dart
@@ -7,7 +7,7 @@ import '../../pigeon_build_core.dart';
 
 class PigeonBuildHandler {
   BuildHandlerResult handleInput(PigeonBuildConfig config, String inputPath) {
-    final nInputPath = p.normalize(inputPath);
+    final nInputPath = normalizePath(inputPath);
     final mainInput = config.mainInput;
 
     if (p.extension(nInputPath) != ".dart") {
@@ -223,7 +223,7 @@ class PigeonBuildHandler {
       result = p.join(basePath, path);
     }
 
-    return p.normalize(result);
+    return normalizePath(result);
   }
 
   String? combinePackage(String? package, String? basePackage) {
@@ -236,5 +236,9 @@ class PigeonBuildHandler {
     }
 
     return package;
+  }
+
+  String normalizePath(String path) {
+    return p.normalize(path).replaceAll('\\', '/');
   }
 }


### PR DESCRIPTION
It seems that build_runner expects paths to use forward slash as the separator. When running on Windows, build_runner never generates any files because the "extensions" provided by pigeon_build_runner use back slashes and so don't match build_runner's paths.

This PR ensures that all paths use forward slashes.