### PR TITLE
Fixed path to pigeon lib starting with Pigeon 24.0.0

### DIFF
--- a/packages/pigeon_build_core/lib/src/extensions/pigeon_options_extension.dart
+++ b/packages/pigeon_build_core/lib/src/extensions/pigeon_options_extension.dart
@@ -1,4 +1,4 @@
-import 'package:pigeon/pigeon_lib.dart';
+import 'package:pigeon/pigeon.dart';
 
 extension PigeonOptionsExtension on PigeonOptions {
   List<String> getAllOutputs() {

--- a/packages/pigeon_build_core/lib/src/models/build_handler_result.dart
+++ b/packages/pigeon_build_core/lib/src/models/build_handler_result.dart
@@ -1,4 +1,4 @@
-import 'package:pigeon/pigeon_lib.dart';
+import 'package:pigeon/pigeon.dart';
 import 'package:pigeon_build_config/pigeon_build_config.dart';
 
 class BuildHandlerResult {

--- a/packages/pigeon_build_core/pubspec.yaml
+++ b/packages/pigeon_build_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pigeon_build_core
 description: A core package for pigeon_build_runner
-version: 1.1.1
+version: 2.0.0
 homepage: https://github.com/rotorgames/pigeon_build_runner
 repository: https://github.com/rotorgames/pigeon_build_runner
 issue_tracker: https://github.com/rotorgames/pigeon_build_runner/issues
@@ -13,7 +13,7 @@ dependencies:
   path: ^1.8.2
   meta: ^1.9.1
   recase: ^4.1.0
-  pigeon: ">=4.2.8"
+  pigeon: ">=24.0.0"
   pigeon_build_config: ^1.1.0
 
 dev_dependencies:

--- a/packages/pigeon_build_runner/lib/src/pigeon_builder.dart
+++ b/packages/pigeon_build_runner/lib/src/pigeon_builder.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:build/build.dart';
-import 'package:pigeon/pigeon_lib.dart';
+import 'package:pigeon/pigeon.dart';
 import 'package:pigeon_build_config/pigeon_build_config.dart';
 import 'package:pigeon_build_core/pigeon_build_core.dart';
 import 'package:scratch_space/scratch_space.dart';

--- a/packages/pigeon_build_runner/pubspec.yaml
+++ b/packages/pigeon_build_runner/pubspec.yaml
@@ -4,16 +4,16 @@ homepage: https://github.com/rotorgames/pigeon_build_runner
 repository: https://github.com/rotorgames/pigeon_build_runner
 issue_tracker: https://github.com/rotorgames/pigeon_build_runner/issues
 documentation: https://github.com/rotorgames/pigeon_build_runner/blob/main/README.md
-version: 1.1.1
+version: 2.0.0
 
 environment:
   sdk: '>=2.18.4 <4.0.0'
 
 dependencies:
   pigeon_build_config: ^1.1.0
-  pigeon_build_core: ^1.1.1
+  pigeon_build_core: ^2.0.0
   build: ^2.4.0
-  pigeon: ">=4.2.8"
+  pigeon: ">=24.0.0"
   scratch_space: ^1.0.0
   path: ^1.8.3
 


### PR DESCRIPTION
The name of the main Pigeon Dart file changed from `pigeon_lib.dart` to `pigeon_dart` with version 24.0.0. This makes current pigeon_build_runner version 1.1.1 incompatible.
This PR updates the import paths and raises the version to 2.0.0 of core and runner.

Issue: #4 